### PR TITLE
Replacing --query flag with --sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ S3SQL is a lightweight command line utility for querying data stored in s3.
 6. Query an object with the following command:
 
    ```bash
-   s3sql query --uri "s3://s3sql-demo/sql_engines.csv" --query "SELECT * FROM df WHERE 1=1"
+   s3sql query --uri "s3://s3sql-demo/sql_engines.csv" --sql "SELECT * FROM df WHERE 1=1"
    ```
 
    This command returns a formatted table of the data from the specified object:
@@ -108,7 +108,7 @@ S3SQL is a lightweight command line utility for querying data stored in s3.
    Apply a `LIMIT 1` to the previous query:
 
    ```bash
-   s3sql query --uri "s3://s3sql-demo/sql_engines.csv" --query "SELECT * FROM df WHERE 1=1 LIMIT 1"
+   s3sql query --uri "s3://s3sql-demo/sql_engines.csv" --sql "SELECT * FROM df WHERE 1=1 LIMIT 1"
    ```
 
    This command returns a formatted table of the data from the specified object:
@@ -124,7 +124,7 @@ S3SQL is a lightweight command line utility for querying data stored in s3.
 7. Query an object and output the query results to a file with the following command:
 
    ```bash
-   s3sql query --uri "s3://s3sql-demo/folder_example/sql_database_releases.csv" --query "SELECT * FROM df WHERE 1=1 LIMIT 1" --out "output.csv"
+   s3sql query --uri "s3://s3sql-demo/folder_example/sql_database_releases.csv" --sql "SELECT * FROM df WHERE 1=1 LIMIT 1" --out "output.csv"
    ```
 
    This command returns a formatted table of the data with an additional message specifying the filename the data was written to:
@@ -142,7 +142,7 @@ S3SQL is a lightweight command line utility for querying data stored in s3.
 8. Query an object within the `folder_example` folder with the following command:
 
    ```bash
-   s3sql query --uri "s3://s3sql-demo/folder_example/sql_database_releases.csv" --query "SELECT * FROM df WHERE 1=1"
+   s3sql query --uri "s3://s3sql-demo/folder_example/sql_database_releases.csv" --sql "SELECT * FROM df WHERE 1=1"
    ```
 
    This command returns a formatted table of the data from the specified object:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ S3SQL is a lightweight command line utility for querying data stored in s3.
 
 ## Demo
 
-![s3sql](https://github.com/user-attachments/assets/1069c9e2-1c9b-4c27-a4b7-16ae274c543d)
+![s3sql](https://github.com/user-attachments/assets/8fc57375-0498-4f0b-ae2f-f90a94452dca)
 
 ## Installation
 1. Install with:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ S3SQL is a lightweight command line utility for querying data stored in s3.
 
 ## Demo
 
-![s3sql](https://github.com/user-attachments/assets/90df0ae1-52b2-4b6b-aa9f-21421a73a7f5)
+![s3sql](https://github.com/user-attachments/assets/1069c9e2-1c9b-4c27-a4b7-16ae274c543d)
 
 ## Installation
 1. Install with:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ S3SQL is a lightweight command line utility for querying data stored in s3.
    This command returns a formatted table of the data from the specified object:
 
    ```bash
+   Query executed in 0.3591 seconds
    +---------------+------------------------+-------------------------------------+------------------------------------+--------------------------+
    | engine_name   |   initial_release_year | designer                            | organization                       | current_stable_version   |
    +===============+========================+=====================================+====================================+==========================+
@@ -163,9 +164,57 @@ S3SQL is a lightweight command line utility for querying data stored in s3.
    +---------------+------------------------+-------------------------------------+------------------------------------+--------------------------+
    ```
 
+9. Query an object and save the output to your local file system using the following command:
+
+   ```bash
+   s3sql query --uri "s3://s3sql-demo/folder_example/sql_database_releases.csv" --sql "SELECT * FROM df WHERE 1=1 LIMIT 1" --out "output.csv"
+   ```
+
+   This command returns a formatted table of the data from the specified object and an additional `Data successfully written to file: output.csv`:
+
+   ```bash
+   Query executed in 0.3391 seconds
+   +---------------+------------------------+-------------------------------------+------------------------------------+--------------------------+
+   | engine_name   |   initial_release_year | designer                            | organization                       | current_stable_version   |
+   +===============+========================+=====================================+====================================+==========================+
+   | SQLite        |                   2000 | D. Richard Hipp                     | Hipp Wyrick & Company              | 3.50.1                   |
+   +---------------+------------------------+-------------------------------------+------------------------------------+--------------------------+
+   | PostgreSQL    |                   1986 | Michael Stonebraker                 | University of California  Berkeley | 16.4                     |
+   +---------------+------------------------+-------------------------------------+------------------------------------+--------------------------+
+   | MySQL         |                   1995 | Michael Widenius and David Axmark   | MySQL AB                           | 8.4                      |
+   +---------------+------------------------+-------------------------------------+------------------------------------+--------------------------+
+   | SQLServer     |                   1989 | Donald Chamberlin and Raymond Boyce | Microsoft Corporation              | 2022                     |
+   +---------------+------------------------+-------------------------------------+------------------------------------+--------------------------+
+   | DuckDB        |                   2019 | Mark Raasveldt and Hannes Muhleisen | Centrum Wiskunde & Informatica     | 1.0.0                    |
+   +---------------+------------------------+-------------------------------------+------------------------------------+--------------------------+
+   Data successfully written to file: output.csv
+   ```
+
+10. Query a `.csv` object and convert it to a `.parquet` file with the following command:
+
+   ```bash
+   s3sql query --uri "s3://s3sql-demo/sql_engines.csv" --sql "SELECT * FROM df WHERE 1=1 LIMIT 1" --out "output.parquet"
+   ```
+
+   This command returns a formatted table of the data from the specified object and an additional `Data successfully written to file: output.parquet`:
+
+   ```bash
+   Query executed in 0.3399 seconds
+   +------+---------------+-----------+----------------+-----------------+--------------------+
+   |   Id | engine_name   |   version | license_type   | developer       | primary_use_case   |
+   +======+===============+===========+================+=================+====================+
+   |    1 | SQLite        |      3.46 | Public Domain  | D. Richard Hipp | Embedded systems   |
+   +------+---------------+-----------+----------------+-----------------+--------------------+
+   Data successfully written to file: output.parquet
+   ```
+
 ## Directory Structure
+
 ```
 project/
+├── .github/
+│   └── workflows/
+│       └── publish.yml
 ├── dist/
 │   └── s3sql-*.*.*-py3-none-any.whl
 │   └── s3sql-*.*.*.tar.gz
@@ -185,6 +234,10 @@ project/
 
   ![image](https://github.com/user-attachments/assets/687b6894-779b-4fd1-8a53-17b6e143a25d)
 
+## Github
+
+https://github.com/Ian-Fogelman/s3sql
+
 ## Contributing
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/your-feature`)
@@ -197,6 +250,7 @@ project/
 ## PyPI
 
 https://pypi.org/project/s3sql/
+
 
 ## License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Ian Fogelman <IanFogelman@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 click = "^8.1.3"
 requests = "^2.32.3"
 duckdb = "^1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "s3sql"
-version = "0.0.2"
+version = "0.0.3"
 
 description = "A simple CLI to query cloud storage objects with SQL."
 authors = ["Ian Fogelman <IanFogelman@gmail.com>"]

--- a/s3sql/cli.py
+++ b/s3sql/cli.py
@@ -100,9 +100,9 @@ def get_secret():
 
 @cli.command()
 @click.option('--uri', prompt='Enter a quoted S3 URI for the object', hide_input=True, help='Example: s3://osg-repo-scan-data/branches.csv')
-@click.option('--query', prompt='Enter a quoted SQL query for the data returned from the object', hide_input=True, help='Example: SELECT * FROM df WHERE ID > 1')
+@click.option('--sql', prompt='Enter a quoted SQL query for the data returned from the object', hide_input=True, help='Example: SELECT * FROM df WHERE ID > 1')
 @click.option('--out', default=None, hide_input=True, help='Example: output.csv') #no "prompt", makes optional, only set if writing to file.
-def query(uri,query,out):
+def query(uri,sql,out):
     start = time.time()
     """Query an object stored in S3."""
     config = get_config()
@@ -124,7 +124,7 @@ def query(uri,query,out):
     rm = details['read_method']
     q = "SELECT * FROM {read}('{uri}');".format(read=rm,uri=uri)
     df = conn.execute(q).df()
-    df = duckdb.query(query).df()
+    df = duckdb.query(sql).df()
     end = time.time()
     click.echo(f"Query executed in {end - start:.4f} seconds")
     click.echo(tabulate(df, headers='keys', tablefmt='grid', showindex=False)) #psql, grid, plain, fancy_grid

--- a/s3sql/test_cli.py
+++ b/s3sql/test_cli.py
@@ -24,10 +24,10 @@ def test_get_secret():
     assert('Stored API secret:' in result_str)
 
 def test_query_csv():
-    #s3sql query --uri "s3://s3sql-demo/folder_example/sql_database_releases.csv" --query "SELECT * FROM df WHERE 1=1 LIMIT 1" --out "output.csv"
+    #s3sql query --uri "s3://s3sql-demo/folder_example/sql_database_releases.csv" --sql "SELECT * FROM df WHERE 1=1 LIMIT 1" --out "output.csv"
     output_file = 'output.csv'
     result = runner.invoke(query, ['--uri','s3://s3sql-demo/sql_engines.csv',
-                                   '--query','SELECT * FROM df WHERE 1=1',
+                                   '--sql','SELECT * FROM df WHERE 1=1',
                                    '--out',output_file])
     result_str = result.output
     df = pd.read_csv('output.csv')
@@ -35,10 +35,10 @@ def test_query_csv():
     assert(check_result_message(result_str) == True)
 
 def test_query_json():
-    #s3sql query --uri "s3://s3sql-demo/json/database_default_ports.json" --query "SELECT * FROM df WHERE 1=1" --out "output.json"
+    #s3sql query --uri "s3://s3sql-demo/json/database_default_ports.json" --sql "SELECT * FROM df WHERE 1=1" --out "output.json"
     output_file = 'output.json'
     result = runner.invoke(query, ['--uri','s3://s3sql-demo/json/database_default_ports.json',
-                                   '--query','SELECT * FROM df WHERE 1=1',
+                                   '--sql','SELECT * FROM df WHERE 1=1',
                                    '--out',output_file])
     result_str = result.output
     df = pd.read_json(output_file)
@@ -46,10 +46,10 @@ def test_query_json():
     assert(check_result_message(result_str) == True)
 
 def test_query_parquet():
-    #s3sql query --uri "s3://s3sql-demo/parquet/database_features.parquet" --query "SELECT * FROM df WHERE 1=1" --out "output.parquet"
+    #s3sql query --uri "s3://s3sql-demo/parquet/database_features.parquet" --sql "SELECT * FROM df WHERE 1=1" --out "output.parquet"
     output_file = 'output.parquet'
     result = runner.invoke(query, ['--uri','s3://s3sql-demo/parquet/database_features.parquet',
-                                   '--query','SELECT * FROM df WHERE 1=1',
+                                   '--sql','SELECT * FROM df WHERE 1=1',
                                    '--out',output_file])
     result_str = result.output
     df = pd.read_parquet(output_file)


### PR DESCRIPTION
- Updating flag `--query` to `--sql`
- Unit test updates for the new `--sql` flag
- Updating minimum python version to `3.9`
- `README.md` updates
- Demo video updates
- Bumping `s3sql` version to `0.0.3`
- First successful GH Action run: https://github.com/Ian-Fogelman/s3sql/actions/runs/15866106123/job/44733194648

![s3sqldemo_latest](https://github.com/user-attachments/assets/8fc57375-0498-4f0b-ae2f-f90a94452dca)

