### PR TITLE
Create examples directory

### DIFF
--- a/examples/pipeline.bat
+++ b/examples/pipeline.bat
@@ -1,0 +1,1 @@
+s3sql query --uri "s3://s3sql-demo/folder_example/sql_database_releases.csv" --sql "SELECT COUNT(*) as CNT FROM df WHERE 1=1" --out "output.csv"


### PR DESCRIPTION
- Examples folder holds examples of piratical ways to use s3sql for simple etl jobs.